### PR TITLE
[Feature] Support optional switch to ROS platform controller rather than kelo_tulip

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ angular:
   z: 0.0" -r 10
 ~~~
 
+### Disabling kelo_tulip platform controller
+
+The `kelo_tulip` platform controller requires information about every continuous (or movable) joint in all the connected KELO Drives. Moreover, it sends control data for every hub wheel. This can potentially increase the simulation load on weaker computers. If the goal of simulation is to move the robot around without worrying about the platform controller used, then `kelo_tulip` can be switched off and the more simpler [gazebo_ros_planar_move](https://classic.gazebosim.org/tutorials?tut=ros_gzplugins#PlanarMovePlugin) platform controller can be used. To start the simulation with the `gazebo_ros_planar_move` instead of `kelo_tulip` use the below command:
+
+~~~ sh
+roslaunch robile_gazebo 4_wheel_platform.launch use_kelo_tulip:=false
+~~~
+
 ### Moving the robot using a keyboard
 
 The [teleop_twist_keyboard](http://wiki.ros.org/teleop_twist_keyboard) ROS package can be used to simplify controlling the motion of the robot. This requires a one time installation of the `teleop_twist_keyboard` package using the below command:
@@ -189,7 +197,11 @@ A platform specific launch file can be defined as follows:
     ~~~ xml
     <arg name="platform_config" value="simple_config"/>
     ~~~
-4. Finally list all the hub wheel controller names defined in the `config/ros_controller/simple_config.yaml` file as follows:
+4. Add an argument to specify if `kelo_tulip` must be used as the platform controller by default. If this is set to false, all the wheel and pivot joints will be treated as fixed and the `gazebo_ros_planar_move` plugin will be used as the platform controller.
+    ~~~ xml
+    <arg name="use_kelo_tulip" default="true"/>
+    ~~~
+5. Finally list all the hub wheel controller names defined in the `config/ros_controller/simple_config.yaml` file as follows:
     ~~~ xml
     <arg name="hub_wheel_controller_list" 
          value="robile_3_left_hub_wheel_controller
@@ -197,7 +209,7 @@ A platform specific launch file can be defined as follows:
                 robile_4_left_hub_wheel_controller
                 robile_4_right_hub_wheel_controller" />
     ~~~
-5. The complete ros launch file should look something like the one shown below:
+6. The complete ros launch file should look something like the one shown below:
     ~~~ xml
     <?xml version="1.0"?>
     <launch>
@@ -205,6 +217,7 @@ A platform specific launch file can be defined as follows:
             Platform specific arguments must be defined here
         -->
         <arg name="platform_config" value="simple_config"/>
+        <arg name="use_kelo_tulip" default="true"/>
         <arg name="hub_wheel_controller_list" 
              value="robile_3_left_hub_wheel_controller
                     robile_3_right_hub_wheel_controller

--- a/launch/2_wheel_platform.launch
+++ b/launch/2_wheel_platform.launch
@@ -6,6 +6,7 @@
         wheel controller list
     -->
     <arg name="platform_config" value="2_wheel_config"/>
+    <arg name="use_kelo_tulip" default="true"/>
     <arg name="hub_wheel_controller_list" 
          value="robile_6_left_hub_wheel_controller
                 robile_6_right_hub_wheel_controller

--- a/launch/4_wheel_platform.launch
+++ b/launch/4_wheel_platform.launch
@@ -6,6 +6,7 @@
         wheel controller list
     -->
     <arg name="platform_config" value="4_wheel_config"/>
+    <arg name="use_kelo_tulip" default="true"/>
     <arg name="hub_wheel_controller_list" 
          value="robile_2_left_hub_wheel_controller
                 robile_2_right_hub_wheel_controller

--- a/launch/6_wheel_platform.launch
+++ b/launch/6_wheel_platform.launch
@@ -6,6 +6,7 @@
         wheel controller list
     -->
     <arg name="platform_config" value="6_wheel_config"/>
+    <arg name="use_kelo_tulip" default="true"/>
     <arg name="hub_wheel_controller_list" 
          value="robile_1_left_hub_wheel_controller
                 robile_1_right_hub_wheel_controller

--- a/launch/platform_independent/robile_gazebo.launch
+++ b/launch/platform_independent/robile_gazebo.launch
@@ -3,6 +3,7 @@
 <launch>
     <!-- platform_configuration options -->
     <arg name="platform_config"/> <!-- (must be defined in the 'robile_description' ros package) -->
+    <arg name="use_kelo_tulip" default="true"/>
     <arg name="hub_wheel_controller_list"/>
     <arg name="platform_max_lin_vel" default="1.0"/> <!-- in m/s -->
     <arg name="platform_max_ang_vel" default="1.0"/> <!-- in rad/s -->
@@ -34,7 +35,10 @@
     </include>
 
     <!-- launch robot in Gazebo -->
-    <param name="robot_description" command="$(find xacro)/xacro '$(find robile_description)/gazebo/gazebo_robile.xacro' platform_config:=$(arg platform_config)" />
+    <param if="$(arg use_kelo_tulip)" name="robot_description"
+           command="$(find xacro)/xacro '$(find robile_description)/gazebo/gazebo_robile.xacro' platform_config:=$(arg platform_config)"/>
+    <param unless="$(arg use_kelo_tulip)" name="robot_description"
+           command="$(find xacro)/xacro '$(find robile_description)/gazebo/gazebo_robile.xacro' platform_config:=$(arg platform_config) movable_joints:=false"/>
     <node pkg="gazebo_ros" type="spawn_model" name="spawn_robot" respawn="false" output="screen" args="-param robot_description
         -urdf
         -x $(arg init_pos_x)
@@ -49,17 +53,19 @@
         <param name="publish_frequency" type="double" value="30.0" />
     </node>
 
-    <!-- Load joint controller configurations from YAML file to parameter server -->
-    <rosparam file="$(find robile_gazebo)/config/ros_controller/$(arg platform_config).yaml" command="load"/>
+    <group if="$(arg use_kelo_tulip)">
+        <!-- Load joint controller configurations from YAML file to parameter server -->
+        <rosparam file="$(find robile_gazebo)/config/ros_controller/$(arg platform_config).yaml" command="load"/>
 
-    <!-- Start the Gazebo platform controller node -->
-    <param name="platform_max_lin_vel" type="double" value="$(arg platform_max_lin_vel)"/>
-    <param name="platform_max_ang_vel" type="double" value="$(arg platform_max_ang_vel)"/>
-    <node name="robile_gazebo_platform_controller" pkg="robile_gazebo" type="robile_gazebo_platform_controller" />
+        <!-- Start the Gazebo platform controller node -->
+        <param name="platform_max_lin_vel" type="double" value="$(arg platform_max_lin_vel)"/>
+        <param name="platform_max_ang_vel" type="double" value="$(arg platform_max_ang_vel)"/>
+        <node name="robile_gazebo_platform_controller" pkg="robile_gazebo" type="robile_gazebo_platform_controller" />
 
-    <!-- spawn controllers -->
-    <node name="robile_ros_controller_spawner" pkg="controller_manager" type="spawner" output="screen" 
-          args="joint_state_controller $(arg hub_wheel_controller_list)" />
+        <!-- spawn controllers -->
+        <node name="robile_ros_controller_spawner" pkg="controller_manager" type="spawner" output="screen" 
+            args="joint_state_controller $(arg hub_wheel_controller_list)" />
+    </group>
 
     <!-- (Optional) Start RViz -->
     <node pkg="rviz" type="rviz" name="robile_rviz" args="-d $(arg rviz_config)" if="$(arg start_rviz)"/>


### PR DESCRIPTION
With this PR, it should be possible to use the [gazebo_ros_planar_move](https://classic.gazebosim.org/tutorials?tut=ros_gzplugins#PlanarMovePlugin) instead of `kelo_tulip`.

To start the simulation without `kelo_tulip` start the simulation with the `use_kelo_tulip` flag set to `false` as shown below
```
roslaunch robile_gazebo 4_wheel_platform.launch use_kelo_tulip:=false
```

This PR depends on the https://github.com/kelo-robotics/robile_description/pull/1